### PR TITLE
Обхід каталогу питав групу фондів там, де груп немає

### DIFF
--- a/src/nyshporka/sources/archium.py
+++ b/src/nyshporka/sources/archium.py
@@ -664,9 +664,22 @@ class ArchiumSource:
             return self._inventory_cases(ident)
         raise SourceError(f"незрозуміла адреса: {ref!r}")
 
-    def _group_fonds(self, group_id: str) -> list[Node]:
+    def _fonds(self, group_id: str | None) -> list[Node]:
+        """Перелік фондів: у майданчика з групами — по групі, без груп — суцільно.
+
+        🔴 `group_id=None` — не косметика. У майданчика без груп
+        `/api/v1/fond-groups/1/` віддає HTTP 500, тож обхід, який завжди питає
+        групу, для такого архіву неможливий у принципі. Гірше за саме падіння
+        те, як воно виглядає: помилка звинувачує відсічку за темпом або
+        лежачий хост, тобто постійну структурну невідповідність подає як
+        тимчасову мережеву — і той, хто це побачив, чекає й пробує ще раз.
+        Розмітка обох перекликів однакова (`table.fond-groups`), тож розбирає
+        їх той самий `parse_fonds`.
+        """
+        node = f"/api/v1/fond-groups/{group_id}/" if group_id else "/api/v1/fonds/"
+
         def url(page: int) -> str:
-            return (f"/api/v1/fond-groups/{group_id}/?Limit={PAGE_LIMIT}&Page={page}"
+            return (f"{node}?Limit={PAGE_LIMIT}&Page={page}"
                     f"&SortField=FondNumber&SortOrder=asc")
 
         with self.http.client() as c:
@@ -676,6 +689,9 @@ class ArchiumSource:
                 nxt = self.http.get(url(page), client=c).json().get("View", "") or ""
                 out.extend(parse_fonds(nxt))
         return out
+
+    def _group_fonds(self, group_id: str) -> list[Node]:
+        return self._fonds(group_id)
 
     def _inventory_rows(self, inv_id: str) -> list[CaseRow]:
         def url(page: int) -> str:
@@ -708,6 +724,22 @@ class ArchiumSource:
                       "inv_label", "file_id", "case_no", "date", "sheets",
                       "description")
 
+    def _walk_groups(self, groups: tuple[str, ...] | None) -> tuple[str | None, ...]:
+        """Що саме обходити: групи фондів або суцільний перелік.
+
+        🔴 Мовчки зігнорувати переданий `--groups` там, де груп немає,
+        не можна: людина просила частину архіву, а дістала б увесь — і дізналась
+        би про це аж за часом обходу.
+        """
+        if not self.site.fond_groups:
+            if groups:
+                raise SourceError(
+                    f"{self.label}: груп фондів у цього майданчика немає — "
+                    f"обхід іде суцільним переліком, і `--groups` тут нічого не "
+                    f"обмежує. Заберіть аргумент, щоб обійти архів повністю.")
+            return (None,)
+        return tuple(groups or self.DEFAULT_GROUPS)
+
     def crawl(self, groups: tuple[str, ...] | None = None, *,
               on_progress: ProgressFn | None = None,
               resume: bool = True) -> dict[str, int]:
@@ -738,8 +770,8 @@ class ArchiumSource:
                                extrasaction="ignore")
             if new_file:
                 w.writeheader()
-            for group in (groups or self.DEFAULT_GROUPS):
-                fonds = self._group_fonds(group)
+            for group in self._walk_groups(groups):
+                fonds = self._fonds(group)
                 for i, fond in enumerate(fonds, 1):
                     fond_id = fond.ref.partition(":")[2]
                     if fond_id in done:
@@ -753,7 +785,7 @@ class ArchiumSource:
                         stats["inventories"] += 1
                         for row in self._inventory_rows(inv_id):
                             w.writerow({
-                                "group_id": group, "fond_id": fond_id,
+                                "group_id": group or "", "fond_id": fond_id,
                                 "fond_no": fond_no, "fond_title": title,
                                 "inv_id": inv_id, "inv_label": inv.label,
                                 "file_id": row.file_id, "case_no": row.number,

--- a/tests/test_sources_archium.py
+++ b/tests/test_sources_archium.py
@@ -401,3 +401,52 @@ def test_snapshot_has_no_test_rows_of_the_archive() -> None:
         rows = list(csv.DictReader(fh, delimiter="\t"))
     assert not [r for r in rows if r["case_no"].strip() == "Справа 0"]
     assert not [r for r in rows if "test" in (r["inv_label"] or "").lower()]
+def test_crawl_walks_flat_where_the_site_has_no_fond_groups(
+        tmp_path: Path, fond_html: str) -> None:
+    """🔴 У ЦДІАК груп фондів немає: `/api/v1/fond-groups/1/` — HTTP 500.
+
+    Обхід, що завжди питає групу, для такого майданчика падав завжди, і падав
+    повідомленням про відсічку за темпом — постійну ваду видавав за тимчасову.
+    Приймач тут — ЯКУ адресу спитали, а не скільки справ зібрали: каталог на
+    правильній адресі зібрався б і з помилковою гілкою, якби фікстура відповіла
+    на обидві.
+    """
+    from nyshporka.archives.pack import Site
+    from nyshporka.sources.http import Fetcher
+
+    flat = ('<table class="fond-groups"><tbody><tr>'
+            '<td>18</td><td><a href="/fonds/13630/">Церкви</a></td>'
+            '<td>1795-1927</td><td>3160</td></tr></tbody></table>')
+    inv = (FIX / "archium_inventory.json").read_text(encoding="utf-8")
+    empty = json.dumps({"Status": 1, "View": ""})
+    rec = _Recorded({
+        r"/api/v1/fonds/\?Limit=\d+&Page=1(?!\d)": json.dumps({"Status": 1, "View": flat}),
+        r"/api/v1/fonds/": empty,
+        r"/fonds/13630/": fond_html,
+        r"inventories/\d+\?Limit=\d+&Page=1(?!\d)": inv,
+        r"inventories": empty,
+    })
+    site = Site(engine="archium", url="https://архів",
+                source_id="archium-cdiak", fond_groups=False)
+    src = A.ArchiumSource(workspace=tmp_path, site=site, repo="CDIAK",
+                          fetcher=Fetcher(base="https://архів", delay=0.0, client=rec))
+
+    stats = src.crawl()
+
+    assert stats["cases"] == 50
+    assert not any("fond-groups" in u for u in rec.asked), (
+        "обхід спитав групу фондів у майданчика, який їх не має — "
+        f"адреси: {rec.asked}")
+
+
+def test_crawl_says_groups_mean_nothing_where_there_are_none(tmp_path: Path) -> None:
+    """Мовчазне ігнорування `--groups` віддало б увесь архів замість частини."""
+    from nyshporka.archives.pack import Site
+    from nyshporka.sources.http import Fetcher
+
+    site = Site(engine="archium", url="https://архів",
+                source_id="archium-cdiak", fond_groups=False)
+    src = A.ArchiumSource(workspace=tmp_path, site=site, repo="CDIAK",
+                          fetcher=Fetcher(base="https://архів", delay=0.0))
+    with pytest.raises(SourceError, match="груп фондів"):
+        src.crawl(("1",))


### PR DESCRIPTION
## Що не так

`nysh crawl archium-cdiak` падає завжди — не інколи, не під навантаженням.

ЦДІАК не має дерева груп фондів: `/api/v1/fond-groups/1/…` віддає HTTP 500.
Пак це вже знає — `Site(engine="archium", url="https://archium.cdiak.archives.gov.ua", fond_groups=False)`.
І `browse()` цю властивість читає, відповідаючи чесно:

> переліку груп фондів у цього архіву немає — його API на такий запит відповідає помилкою

А `crawl()` ту саму властивість не читає: він іде по `groups or self.DEFAULT_GROUPS`
(тобто `("1",)`) і кличе `_group_fonds()` безумовно. Дві гілки одного джерела
розійшлись у знанні про той самий майданчик.

## Чому це гірше, ніж просто падіння

Помилка, яку бачить користувач, звинувачує мережу:

```
HttpError: …/api/v1/fond-groups/1/?Limit=…: HTTP 500 після 6 спроб.
⚠ Це може бути і відсічка за темпом, і те, що хост лежить, —
розрізняє їх лише проба з іншого IP (NYSHPORKA_PROXY_URL).
```

Це повідомлення правдиве для тимчасової відмови й хибне тут: невідповідність
постійна, і чекати чи пробувати з іншого IP не допоможе ніколи. Той, хто його
побачив, спробує ще раз, потім через годину, потім через проксі — і лише потім
піде читати код. Рівно та вада, проти якої писане правило «нуль мусить щось
означати»: тут «не зміг» виглядає як «мережа підвела».

## Що зроблено

`_fonds(group_id)` бере перелік фондів звідти, звідки цей майданчик його
віддає: `/api/v1/fonds/`, коли груп немає, і `/api/v1/fond-groups/{id}/`, коли
вони є. Розмітка обох перекликів однакова (`table.fond-groups`), тож розбирає
їх той самий `parse_fonds` — нового парсера не додано. `_group_fonds()`
лишився тонкою обгорткою, щоб `browse()` не чіпати.

Переданий `--groups` там, де груп немає, тепер **відмова**, а не мовчазне
ігнорування: інакше людина просить частину архіву, а дістає весь — і дізнається
про це аж за часом обходу.

## Перевірено

На живому ЦДІАК через пропатчений код:

```
майданчик: ARCHIUM (ЦДІАК) https://archium.cdiak.archives.gov.ua  групи: False
обходимо: (None,)
фондів: 1597
   fond:1 | ф.1 Колекція документів Скарбу коронного · 1546-1792
   fond:2 | ф.2 Гродський суд Київського воєводства, м. Житомир …
```

Було — виняток на першому ж запиті.

Ворота репозиторію:

| | |
|---|---|
| `ruff check .` | All checks passed |
| `mypy` | Success: no issues found in 168 source files |
| `pytest` | **1130 passed**, 31 skipped |
| `tools/scan_private.py --history` | ✅ приватних даних не знайдено (1457 файлів) |

## Тести

Два, обидва на записаних відповідях (мережі немає):

* `test_crawl_walks_flat_where_the_site_has_no_fond_groups` — приймач тут
  **яка адреса спитана**, а не скільки справ зібрано: каталог зібрався б і з
  помилковою гілкою, якби фікстура відповіла на обидві адреси, тож перевірка
  саме `assert not any("fond-groups" in u for u in rec.asked)`.
* `test_crawl_says_groups_mean_nothing_where_there_are_none` — `--groups` для
  такого майданчика мусить відмовити.

## Чого не чіпав

`CHANGELOG.md` — там голос автора й прив'язка до релізів; запис за вами.

---
Знайдено під час генеалогічного дослідження: ДАЧкО ARCHIUM-майданчика не має
взагалі, тож я пробував зібрати каталог ЦДІАК — і впав на цьому.
