### PR TITLE
Логотип у шапці тепер посилається на GitHub

### DIFF
--- a/src/nyshporka/daemon/static/app.css
+++ b/src/nyshporka/daemon/static/app.css
@@ -17,6 +17,8 @@
    ньому не працює, тож знак лишався б чорним в обох темах. Маска ж фарбується
    токеном — один файл на світлу й темну. */
 .brand { display: flex; align-items: center; gap: .45rem; }
+.brand.logo { color: inherit; text-decoration: none; }
+.brand.logo:hover { color: var(--accent); }
 .mark {
   width: 1.4em; height: 1.4em; flex: none; background: var(--accent);
   -webkit-mask: url(/brand/mark.svg) center / contain no-repeat;

--- a/src/nyshporka/daemon/static/index.html
+++ b/src/nyshporka/daemon/static/index.html
@@ -55,10 +55,11 @@
     картинки: у SVG воно вимагало б власного шрифту, а той в архіві без
     інтернету не приїхав би.
   -->
-  <span class="brand logo">
+  <a class="brand logo" href="https://github.com/SERGIUSH-UA/nyshporka"
+     target="_blank" rel="noopener" title="Нишпорка на GitHub">
     <span class="mark" aria-hidden="true"></span>
     Нишпорка
-  </span>
+  </a>
   <!--
     🔴 Кнопки СТАВИТЬ JS із `/api/sections`, а не розмітка. Причина не в
     зручності: частину застосунку вимикають профілем простору, і другий,


### PR DESCRIPTION
## Summary
- Логотип у шапці (знак + назва «Нишпорка»), який раніше нікуди не вів, тепер посилається на репозиторій на GitHub.

Виділено з ширшого коміту `ffff79e` (широкі екрани + лого-посилання + підказки зуму) в окремий PR — тут лише лого-посилання.

## Test plan
- [ ] Відкрити консоль, клікнути на логотип у шапці — переходить на https://github.com/SERGIUSH-UA/nyshporka в новій вкладці

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFTU7zkWJYuUb4U2WGAUhi